### PR TITLE
Refactor skeleton removal logic for media elements in image component

### DIFF
--- a/components/image/index.js
+++ b/components/image/index.js
@@ -6,8 +6,10 @@ export class Image extends Controller {
 
     if (!element) return
 
-    if (element?.complete) this.element.classList.remove('before:skeleton')
-    else if (element?.oncanplay) element.oncanplay = () => this.element.classList.remove('before:skeleton')
-    else if (element?.onload) element.onload = () => this.element.classList.remove('before:skeleton')
+    const removeSkeleton = () => this.element.classList.remove('before:skeleton')
+
+    if (element.complete) removeSkeleton()
+    else if (element instanceof HTMLVideoElement) element.oncanplay = removeSkeleton
+    else element.onload = removeSkeleton
   }
 }


### PR DESCRIPTION
Fixed the image skeleton removal logic.

element.onload is usually null until a handler is assigned, mainly with swup, so using it as a condition prevented the load handler from ever being registered. The controller now assigns onload directly for images/iframes, uses oncanplay for videos, and still removes the skeleton immediately when the media is already loaded.